### PR TITLE
Remove autobackup attribute from manifest

### DIFF
--- a/anychart/src/main/AndroidManifest.xml
+++ b/anychart/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.anychart">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
This removes issues when trying to create a project where autobackup is disabled since otherwise it would cause AndroidManifest merger errors. Solves #127