### PR TITLE
Remove config from manifest

### DIFF
--- a/anychart/src/main/AndroidManifest.xml
+++ b/anychart/src/main/AndroidManifest.xml
@@ -1,11 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.anychart">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
This configuration will be used by the manifest merger. This means that this lib could potentially switch on auto backup, define the application name and switch on rtl support  for consumers . This shouldn't be the case so all config has been removed